### PR TITLE
File INSTALL: added useradd-command

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,4 @@
+useradd -d /var/run/bloonix -s /bin/false bloonix
 perl Configure.PL
 make
 make install


### PR DESCRIPTION
The installation will fail without the bloonix user, so it should be mentioned here to create one before calling 'make install'.